### PR TITLE
fix(autofit.js):修复忽略元素在页面尺寸改变时不会更新放大比例

### DIFF
--- a/autofit.js
+++ b/autofit.js
@@ -111,7 +111,9 @@ function keepFit(dw, dh, dom, ignore) {
   currScale = (clientWidth / clientHeight < dw / dh) ? (clientWidth / dw) : (clientHeight / dh)
   dom.style.height = `${clientHeight / currScale}px`;
   dom.style.width = `${clientWidth / currScale}px`;
-  dom.style.transform = `scale(${currScale})`
+  dom.style.transform = `scale(${currScale})`;
+  const ignoreStyleDOM = document.querySelector('#ignoreStyle');
+  ignoreStyleDOM.innerHTML = ''
   for (let item of ignore) {
     let itemEl = item.el || item.dom
     typeof item == 'string' && (itemEl = item)
@@ -124,19 +126,21 @@ function keepFit(dw, dh, dom, ignore) {
     let realWidth = realScale != currScale ? item.width : 'autofit'
     let realHeight = realScale != currScale ? item.height : 'autofit'
     let regex = new RegExp(`${itemEl}(\x20|{)`, 'gm')
-    let isIgnored = regex.test(document.querySelector('#ignoreStyle').innerHTML);
+    let isIgnored = regex.test(ignoreStyleDOM.innerHTML);
     if (isIgnored) {
       continue
     }
-    document.querySelector('#ignoreStyle').innerHTML += `\n${itemEl} { 
+    ignoreStyleDOM.innerHTML += `\n${itemEl} { 
       transform: scale(${realScale})!important;
       transform-origin: 0 0;
       width: ${realWidth}!important;
       height: ${realHeight}!important;
     }`;
-    document.querySelector('#ignoreStyle').innerHTML += `\n${itemEl} div ,${itemEl} span,${itemEl} a,${itemEl} * {
-      font-size: ${realFontSize}px;
-    }`;
+    if (realFontSize) {
+      ignoreStyleDOM.innerHTML += `\n${itemEl} div ,${itemEl} span,${itemEl} a,${itemEl} * {
+        font-size: ${realFontSize}px;
+      }`;
+    }
   }
 }
 export {


### PR DESCRIPTION
- 背景
 本人在看板项目中有幸使用到该插件，由于项目中使用到了高德地图中路线的点击事件。在实际项目中发现点击路线不会触发事件，点击路线旁边会触发，所以就考虑到是否是缩放的问题。将地图元素设置为忽略元素后初始化点击事件是存在的，但是全屏后（改变页面尺寸）事件无法生效。
- 发生原因

1.  插件在keepFit方法中会遍历忽略元素数组，并进行反向缩放操作。但是其中有一个变量isIgnored会在#ignoreStyle样式表存在样式时阻止反向操作。初始化时样式表为空会进行反向操作，但是初始化时也会向样式表中添加样式，当页面尺寸改变时isIgnored就会阻止反向操作，这时整体缩放比例更新，但是忽略元素还是旧尺寸的反向缩放比例且无法改变。
2. 假如isIgnored是永远允许反向操作，由于向#ignoreStyle样式表添加样式的方法是‘+=’，每次改变尺寸都是去累加样式，频繁操作会导致体积无限大。

- 解决方案
 在遍历忽略元素数前将#ignoreStyle样式表清空，首先可以保证页面尺寸变化执行keepFit方法时isIgnored不会阻止方向操作，其次可以保证#ignoreStyle样式表内容是替换不是累加。

